### PR TITLE
connections/models config changes

### DIFF
--- a/hooks/connections.js
+++ b/hooks/connections.js
@@ -14,21 +14,19 @@ module.exports = function Connections(cb) {
 
     async.mapLimit(connections, 5, function(connectionName, fn) {
         var connectionInfo = self._config.connections[connectionName];
+        // TODO is this being used?
+        connectionInfo.name = connectionName;
 
         // verify adapter info
         var adapter = connectionInfo.adapter || false;
         if (!adapter) return fn('Missing adapter for connection: ' + connectionName);
-
-        // remove adapter from connection config so that adapter
-        // doesn't have to whitelist/modify config object
-        delete connectionInfo.adapter;
 
         // verify the adapter implements a `registerConnection` method
         if (!adapter.registerConnection || !_.isFunction(adapter.registerConnection) || adapter.registerConnection.length !== 2) {
             return fn('Invalid adapter api');
         }
 
-        adapter.registerConnection(connectionInfo, function(err, connection) {
+        adapter.registerConnection(connectionInfo.config, function(err, connection) {
             if (err) {
                 self.log('error', err);
                 return fn('There was an error creating the connection (' + connectionName + ')');

--- a/hooks/models.js
+++ b/hooks/models.js
@@ -17,12 +17,12 @@ module.exports = function Models(cb) {
     });
 
     async.mapLimit(_.keys(models), 5, function(name, fn) {
-        // get model definition
-        var modelDefinition = models[name];
-        modelDefinition.name = name;
+        // get model
+        var model = models[name];
+        model.name = name;
 
         // get connection name
-        var connectionName = modelDefinition.connection || self._config.models.connection || false;
+        var connectionName = model.connection || self._config.models.connection || false;
         if (!connectionName) return fn('No connection name specified for model (' + name + ')');
 
         // get connection
@@ -44,7 +44,7 @@ module.exports = function Models(cb) {
         }
 
         // hand off to adapter
-        adapter.registerModel(connection.connection, modelDefinition, function(err, model) {
+        adapter.registerModel(connection.connection, model.definition, function(err, model) {
             if (err) return fn(err);
             self.models[name] = model;
             fn();

--- a/hooks/server.js
+++ b/hooks/server.js
@@ -42,5 +42,10 @@ module.exports = function Server(cb) {
         }
     });
 
+    // TODO discuss placement
+    // parse query and body
+    self.server.use(restify.queryParser());
+    self.server.use(restify.bodyParser({ mapParams: true }));
+
     cb();
 };


### PR DESCRIPTION
moves the connection config and model definition expected by adapters into an isolated property in config/connections.js[config] and config/models/model.js[definition] to prevent any conflicts between restify-microservice config and adapter config
