### PR TITLE
removes modelDefinition.__name from models hook

### DIFF
--- a/hooks/blueprints.js
+++ b/hooks/blueprints.js
@@ -1,0 +1,84 @@
+'use strict';
+var _ = require('lodash');
+
+module.exports = function Blueprints(cb) {
+    var self = this,
+        blueprints = self._config.blueprints,
+        options = ['prefix'], // TODO note reserved option keywords in docs
+        allowedActions = {
+            find: 'get',
+            findOne: 'get',
+            create: 'post',
+            update: 'put',
+            destroy: 'del'
+        },
+        error = function(message, callback) {
+            self.log('error', '[Blueprints] ' + message);
+            return callback(new Error(message));
+        };
+
+    // exit if undefined
+    if(!blueprints) {
+        return cb(null);
+    }
+
+    // iterate through blueprint config attributes
+    _.forIn(blueprints, function(connectionBlueprint, connectionName) {
+
+        // ignore config options
+        if(_.includes(options, connectionName)) {
+            return;
+        }
+
+        // verify connection
+        var connection = self.connections[connectionName];
+        if(!connection) {
+            return error('invalid connection ' + connectionName, cb);
+        }
+
+        // iterate connection blueprint models
+        _.forIn(connectionBlueprint, function(actions, modelName) {
+
+            // verify model
+            var model = self.models[modelName];
+            if(!model) {
+                return error('invalid model ' + modelName, cb);
+            }
+
+            // verify actions
+            actions = _.isArray(actions) ? actions : [actions];
+            actions = _.includes(actions, '*') ? _.keys(allowedActions) : actions;
+            if(!actions.length) {
+                return error('no actions provided for model ' + modelName, cb);
+            }
+            actions.forEach(function(action) {
+                if(!allowedActions[action] && action !== '*') {
+                    return error('invalid blueprint action ' + action, cb);
+                }
+            });
+
+            // create microservice.controllers
+            self.controllers = {};
+
+            // get blueprint controller from adapter
+            connection.adapter.blueprintController(model, actions, function(err, controller) {
+                if(err) {
+                    return error(err, cb);
+                } else {
+                    self.controllers[modelName] = controller;
+
+                    // create blueprint routes (can override in routes config to apply policies, etc.)
+                    // TODO route versioning?
+                    actions.forEach(function(action) {
+                        var verb = allowedActions[action],
+                            route = blueprints.prefix + '/' + modelName;
+                        self.log('silly', '[hook] blueprints :: binding route ' + verb.toUpperCase() + ' ' + route);
+                        self.server[verb](route, self.controllers[modelName][action]);
+                    });
+
+                    return cb(null);
+                }
+            });
+        });
+    });
+};

--- a/hooks/controllers.js
+++ b/hooks/controllers.js
@@ -5,7 +5,7 @@ var include = require('include-all'),
 
 module.exports = function Controllers(cb) {
     var self = this;
-    self.controllers = {};
+    self.controllers = self.controllers ? self.controllers : {};
 
     var controllers = include({
         dirname:  process.cwd() + '/app/controllers',

--- a/hooks/models.js
+++ b/hooks/models.js
@@ -38,6 +38,11 @@ module.exports = function Models(cb) {
                 if (!connectionInfo) {
                     microservice.log('silly', '[models] Unable to find explicit adapter for model (' + name + ')');
                     if (!defaultConnection ) {
+                        console.log('*******************');
+                        console.log('*******************');
+                        console.log(microservice.connections);
+                        console.log('*******************');
+                        console.log('*******************');
                         return _fn('Unable to find adapter for model (' + name + ')');
                     } else {
                         connectionInfo = defaultConnection;

--- a/hooks/models.js
+++ b/hooks/models.js
@@ -32,7 +32,6 @@ module.exports = function Models(cb) {
             asyncjs.each(modelNames, function(name, _fn) {
                 // get model definition
                 var modelDefinition = modelDefinitions[name];
-                modelDefinition.__name = name;
 
                 // get connection info
                 var connectionInfo = lib.findConnection(microservice, name);

--- a/index.js
+++ b/index.js
@@ -88,6 +88,8 @@ var Microservice = function(config) {
     });
 
     self.start = function(done) {
+        console.log('CONFIG', self._config.server);
+        console.log(process.cwd());
         async.eachSeries(
             self._hooks,
             function(hook, fn) {

--- a/test/hooks/blueprints.test.js
+++ b/test/hooks/blueprints.test.js
@@ -1,0 +1,49 @@
+/* jshint expr:true */
+'use strict';
+
+var expect = require('chai').expect,
+    Microservice = require('../../index'),
+    supertest = require('supertest');
+
+
+var cwd,
+    request,
+    ms;
+
+before(function() {
+    cwd = process.cwd();
+    process.chdir(__dirname + '/blueprints/test-app');
+    // TODO understand supertest
+    //request = supertest.agent(microservice.server);
+});
+
+after(function() {
+    process.chdir(cwd);
+});
+
+
+describe('[hook] blueprints', function() {
+
+    describe('controllers', function() {
+
+        beforeEach(function(done) {
+            ms = new Microservice();
+            ms.start(done);
+        });
+
+        it('creates a new controller', function() {
+            expect(ms.controllers.user).to.exist;
+        });
+
+        describe('overriding controllers', function() {
+
+        });
+    });
+
+    describe('routes', function() {
+
+        describe('overriding routes', function() {
+
+        });
+    });
+});

--- a/test/hooks/blueprints/test-app/app/models/user.js
+++ b/test/hooks/blueprints/test-app/app/models/user.js
@@ -1,0 +1,10 @@
+var Joi = require('joi');
+
+module.exports = {
+
+    schema: {
+        first: Joi.string(),
+        last: Joi.string()
+    }
+
+};

--- a/test/hooks/blueprints/test-app/app/routes.js
+++ b/test/hooks/blueprints/test-app/app/routes.js
@@ -1,0 +1,6 @@
+
+module.exports = function() {
+    return {
+
+    };
+};

--- a/test/hooks/blueprints/test-app/config/blueprints.js
+++ b/test/hooks/blueprints/test-app/config/blueprints.js
@@ -1,0 +1,8 @@
+
+module.exports = {
+    prefix: '/api',
+
+    myDatabase: {
+        user: ['find', 'findOne']
+    }
+};

--- a/test/hooks/blueprints/test-app/config/connections.js
+++ b/test/hooks/blueprints/test-app/config/connections.js
@@ -1,0 +1,10 @@
+var blueprintAdapter = require('../../../../test-adapters/blueprints');
+
+module.exports = {
+
+    myDatabase: {
+        adapter: blueprintAdapter,
+        default: true
+    }
+
+};

--- a/test/hooks/blueprints/test-app/config/hooks.js
+++ b/test/hooks/blueprints/test-app/config/hooks.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = [
+    'connections',
+    'models',
+    'server',
+    'services',
+    'policies',
+    'blueprints',
+    'controllers',
+    'routes'
+];

--- a/test/hooks/routes.test.js
+++ b/test/hooks/routes.test.js
@@ -20,10 +20,11 @@ describe('[hook] routes', function() {
         process.chdir(__dirname + '/routes/test-app-no-problems');
 
         var _microservice = new Microservice({});
-
+        console.log('STARTING ROUTE TEST ******************************************')
         _microservice.start(function(err) {
             process.chdir(cwd);
             expect(err).to.not.exist;
+            console.log('ENDING ROUTE TEST ******************************************')
             done();
         });
     });

--- a/test/test-adapters/blueprints.js
+++ b/test/test-adapters/blueprints.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var sinon = require('sinon');
+
+module.exports = {
+
+    registerConnection: function(config, cb) {
+        return cb(null, {});
+    },
+
+    registerModel: function(connection, definition, cb) {
+        cb(null, {
+            find: sinon.stub(),
+            findOne: sinon.stub()
+        });
+    },
+
+    blueprintController: function(model, actions, cb) {
+        var controller = {};
+
+        actions.forEach(function(action) {
+            controller[action] = model[action];
+        });
+
+        cb(null, controller);
+    }
+};

--- a/test/test-adapters/two.js
+++ b/test/test-adapters/two.js
@@ -61,5 +61,18 @@ module.exports = {
         } catch (e) {
             return cb(e);
         }
+    },
+
+    blueprintController: function(model, actions, cb) {
+        var controller = {};
+
+        actions.forEach(function(action) {
+            controller[action] = function(req, res, next) {
+                res.send(200, 'blueprint ' + action);
+                next();
+            }
+        });
+
+        cb(null, controller);
     }
 };


### PR DESCRIPTION
as far as I can tell this attribute isn't being used anywhere and it is causing vogels.js to throw an error when creating models
